### PR TITLE
release: v1.0.32

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "technote/gutenberg-package-versions",
-            "version": "v0.2.88",
+            "version": "v0.2.89",
             "source": {
                 "type": "git",
                 "url": "https://github.com/technote-space/gutenberg-package-versions.git",
-                "reference": "8a5acddbf5a69c00770ae5903837f6b33eab6d49"
+                "reference": "6ff73e548c16ac1b8d9e8eeff5552a903ff99938"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/technote-space/gutenberg-package-versions/zipball/8a5acddbf5a69c00770ae5903837f6b33eab6d49",
-                "reference": "8a5acddbf5a69c00770ae5903837f6b33eab6d49",
+                "url": "https://api.github.com/repos/technote-space/gutenberg-package-versions/zipball/6ff73e548c16ac1b8d9e8eeff5552a903ff99938",
+                "reference": "6ff73e548c16ac1b8d9e8eeff5552a903ff99938",
                 "shasum": ""
             },
             "require": {
@@ -57,7 +57,7 @@
             ],
             "support": {
                 "issues": "https://github.com/technote-space/gutenberg-package-versions/issues",
-                "source": "https://github.com/technote-space/gutenberg-package-versions/tree/v0.2.88"
+                "source": "https://github.com/technote-space/gutenberg-package-versions/tree/v0.2.89"
             },
             "funding": [
                 {
@@ -65,25 +65,25 @@
                     "type": "custom"
                 }
             ],
-            "time": "2020-11-18T17:32:48+00:00"
+            "time": "2020-11-19T17:33:32+00:00"
         },
         {
             "name": "technote/gutenberg-packages",
-            "version": "v1.0.2",
+            "version": "v1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/technote-space/gutenberg-packages.git",
-                "reference": "ace3ae11c422f0d4f41bb0b0343956faa330051c"
+                "reference": "aeb3935a11333b98a7081327d4d64500a5e171ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/technote-space/gutenberg-packages/zipball/ace3ae11c422f0d4f41bb0b0343956faa330051c",
-                "reference": "ace3ae11c422f0d4f41bb0b0343956faa330051c",
+                "url": "https://api.github.com/repos/technote-space/gutenberg-packages/zipball/aeb3935a11333b98a7081327d4d64500a5e171ab",
+                "reference": "aeb3935a11333b98a7081327d4d64500a5e171ab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6",
-                "technote/gutenberg-package-versions": "^0.2.75"
+                "technote/gutenberg-package-versions": "^0.2.82"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || ^0.6.0",
@@ -119,7 +119,7 @@
             ],
             "support": {
                 "issues": "https://github.com/technote-space/gutenberg-packages/issues",
-                "source": "https://github.com/technote-space/gutenberg-packages/tree/v1.0.2"
+                "source": "https://github.com/technote-space/gutenberg-packages/tree/v1.0.3"
             },
             "funding": [
                 {
@@ -127,7 +127,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2020-09-25T04:57:38+00:00"
+            "time": "2020-11-22T09:26:07+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (0310ab18f0f153b1cfdc6b88626cbb104dbb5fe4)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/editor/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer prepare</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs

>> Copy files.
>>>> phpmd.xml
>>>> phpcs.xml
>>>> phpunit.xml
```

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> rm -f ./phpcs.xml ./phpmd.xml ./phpunit.xml
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/prepare.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.0 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 46 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.5)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Locking doctrine/instantiator (1.4.0)
  - Locking myclabs/deep-copy (1.10.2)
  - Locking pdepend/pdepend (2.8.0)
  - Locking phake/phake (v2.3.2)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.0)
  - Locking phpdocumentor/reflection-common (2.2.0)
  - Locking phpdocumentor/reflection-docblock (5.2.2)
  - Locking phpdocumentor/type-resolver (1.4.0)
  - Locking phpmd/phpmd (2.9.1)
  - Locking phpspec/prophecy (v1.10.3)
  - Locking phpunit/php-code-coverage (4.0.8)
  - Locking phpunit/php-file-iterator (1.4.5)
  - Locking phpunit/php-text-template (1.2.1)
  - Locking phpunit/php-timer (1.0.9)
  - Locking phpunit/php-token-stream (2.0.2)
  - Locking phpunit/phpunit (5.7.27)
  - Locking phpunit/phpunit-mock-objects (3.4.4)
  - Locking psr/container (1.0.0)
  - Locking psr/log (1.1.3)
  - Locking sebastian/code-unit-reverse-lookup (1.0.1)
  - Locking sebastian/comparator (1.2.4)
  - Locking sebastian/diff (1.4.3)
  - Locking sebastian/environment (2.0.0)
  - Locking sebastian/exporter (2.0.0)
  - Locking sebastian/global-state (1.1.1)
  - Locking sebastian/object-enumerator (2.0.1)
  - Locking sebastian/recursion-context (2.0.0)
  - Locking sebastian/resource-operations (1.0.0)
  - Locking sebastian/version (2.0.1)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.1.8)
  - Locking symfony/dependency-injection (v5.1.8)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.1.8)
  - Locking symfony/polyfill-ctype (v1.20.0)
  - Locking symfony/polyfill-php80 (v1.20.0)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking symfony/yaml (v4.4.16)
  - Locking technote/gutenberg-package-versions (v0.2.89)
  - Locking technote/gutenberg-packages (v1.0.3)
  - Locking webmozart/assert (1.9.1)
  - Locking wp-coding-standards/wpcs (2.3.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 46 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.5.8)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Downloading sebastian/recursion-context (2.0.0)
  - Downloading sebastian/exporter (2.0.0)
  - Downloading sebastian/diff (1.4.3)
  - Downloading sebastian/comparator (1.2.4)
  - Downloading phake/phake (v2.3.2)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Downloading phpcompatibility/phpcompatibility-wp (2.1.0)
  - Downloading symfony/polyfill-ctype (v1.20.0)
  - Downloading webmozart/assert (1.9.1)
  - Downloading phpdocumentor/reflection-common (2.2.0)
  - Downloading phpdocumentor/type-resolver (1.4.0)
  - Downloading phpdocumentor/reflection-docblock (5.2.2)
  - Downloading symfony/filesystem (v5.1.8)
  - Downloading psr/container (1.0.0)
  - Downloading symfony/service-contracts (v2.2.0)
  - Downloading symfony/polyfill-php80 (v1.20.0)
  - Downloading symfony/deprecation-contracts (v2.2.0)
  - Downloading symfony/dependency-injection (v5.1.8)
  - Downloading symfony/config (v5.1.8)
  - Downloading pdepend/pdepend (2.8.0)
  - Downloading psr/log (1.1.3)
  - Downloading composer/xdebug-handler (1.4.5)
  - Downloading phpmd/phpmd (2.9.1)
  - Downloading phpunit/php-token-stream (2.0.2)
  - Downloading symfony/yaml (v4.4.16)
  - Downloading sebastian/version (2.0.1)
  - Downloading sebastian/resource-operations (1.0.0)
  - Downloading sebastian/object-enumerator (2.0.1)
  - Downloading sebastian/global-state (1.1.1)
  - Downloading sebastian/environment (2.0.0)
  - Downloading phpunit/php-text-template (1.2.1)
  - Downloading doctrine/instantiator (1.4.0)
  - Downloading phpunit/phpunit-mock-objects (3.4.4)
  - Downloading phpunit/php-timer (1.0.9)
  - Downloading phpunit/php-file-iterator (1.4.5)
  - Downloading sebastian/code-unit-reverse-lookup (1.0.1)
  - Downloading phpunit/php-code-coverage (4.0.8)
  - Downloading phpspec/prophecy (v1.10.3)
  - Downloading myclabs/deep-copy (1.10.2)
  - Downloading phpunit/phpunit (5.7.27)
  - Downloading technote/gutenberg-package-versions (v0.2.89)
  - Downloading technote/gutenberg-packages (v1.0.3)
  - Downloading wp-coding-standards/wpcs (2.3.0)
  0/46 [>---------------------------]   0%
  1/46 [>---------------------------]   2%
  2/46 [=>--------------------------]   4%
  3/46 [=>--------------------------]   6%
  4/46 [==>-------------------------]   8%
  5/46 [===>------------------------]  10%
  6/46 [===>------------------------]  13%
  7/46 [====>-----------------------]  15%
  8/46 [====>-----------------------]  17%
  9/46 [=====>----------------------]  19%
 11/46 [======>---------------------]  23%
 12/46 [=======>--------------------]  26%
 13/46 [=======>--------------------]  28%
 15/46 [=========>------------------]  32%
 16/46 [=========>------------------]  34%
 17/46 [==========>-----------------]  36%
 18/46 [==========>-----------------]  39%
 19/46 [===========>----------------]  41%
 20/46 [============>---------------]  43%
 21/46 [============>---------------]  45%
 22/46 [=============>--------------]  47%
 23/46 [==============>-------------]  50%
 24/46 [==============>-------------]  52%
 25/46 [===============>------------]  54%
 26/46 [===============>------------]  56%
 27/46 [================>-----------]  58%
 28/46 [=================>----------]  60%
 29/46 [=================>----------]  63%
 30/46 [==================>---------]  65%
 31/46 [==================>---------]  67%
 32/46 [===================>--------]  69%
 33/46 [====================>-------]  71%
 34/46 [====================>-------]  73%
 35/46 [=====================>------]  76%
 37/46 [======================>-----]  80%
 38/46 [=======================>----]  82%
 39/46 [=======================>----]  84%
 40/46 [========================>---]  86%
 41/46 [========================>---]  89%
 42/46 [=========================>--]  91%
 43/46 [==========================>-]  93%
 44/46 [==========================>-]  95%
 45/46 [===========================>]  97%
 46/46 [============================] 100%  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.0): Extracting archive
  - Installing sebastian/recursion-context (2.0.0): Extracting archive
  - Installing sebastian/exporter (2.0.0): Extracting archive
  - Installing sebastian/diff (1.4.3): Extracting archive
  - Installing sebastian/comparator (1.2.4): Extracting archive
  - Installing phake/phake (v2.3.2): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.0): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.20.0): Extracting archive
  - Installing webmozart/assert (1.9.1): Extracting archive
  - Installing phpdocumentor/reflection-common (2.2.0): Extracting archive
  - Installing phpdocumentor/type-resolver (1.4.0): Extracting archive
  - Installing phpdocumentor/reflection-docblock (5.2.2): Extracting archive
  - Installing symfony/filesystem (v5.1.8): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.20.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.1.8): Extracting archive
  - Installing symfony/config (v5.1.8): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.5): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing phpunit/php-token-stream (2.0.2): Extracting archive
  - Installing symfony/yaml (v4.4.16): Extracting archive
  - Installing sebastian/version (2.0.1): Extracting archive
  - Installing sebastian/resource-operations (1.0.0): Extracting archive
  - Installing sebastian/object-enumerator (2.0.1): Extracting archive
  - Installing sebastian/global-state (1.1.1): Extracting archive
  - Installing sebastian/environment (2.0.0): Extracting archive
  - Installing phpunit/php-text-template (1.2.1): Extracting archive
  - Installing doctrine/instantiator (1.4.0): Extracting archive
  - Installing phpunit/phpunit-mock-objects (3.4.4): Extracting archive
  - Installing phpunit/php-timer (1.0.9): Extracting archive
  - Installing phpunit/php-file-iterator (1.4.5): Extracting archive
  - Installing sebastian/code-unit-reverse-lookup (1.0.1): Extracting archive
  - Installing phpunit/php-code-coverage (4.0.8): Extracting archive
  - Installing phpspec/prophecy (v1.10.3): Extracting archive
  - Installing myclabs/deep-copy (1.10.2): Extracting archive
  - Installing phpunit/phpunit (5.7.27): Extracting archive
  - Installing technote/gutenberg-package-versions (v0.2.89): Extracting archive
  - Installing technote/gutenberg-packages (v1.0.3): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  0/34 [>---------------------------]   0%
 10/34 [========>-------------------]  29%
 20/34 [================>-----------]  58%
 30/34 [========================>---]  88%
 33/34 [===========================>]  97%
 34/34 [============================] 100%11 package suggestions were added by new dependencies, use `composer suggest` to see details.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
15 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for technote/gutenberg-packages
./composer.json has been updated
Running composer update technote/gutenberg-packages
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
15 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
15 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>
<details>
<summary><em>composer packages</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### stderr:

```Shell
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.0 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 46 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.5)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Locking doctrine/instantiator (1.4.0)
  - Locking myclabs/deep-copy (1.10.2)
  - Locking pdepend/pdepend (2.8.0)
  - Locking phake/phake (v2.3.2)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.0)
  - Locking phpdocumentor/reflection-common (2.2.0)
  - Locking phpdocumentor/reflection-docblock (5.2.2)
  - Locking phpdocumentor/type-resolver (1.4.0)
  - Locking phpmd/phpmd (2.9.1)
  - Locking phpspec/prophecy (v1.10.3)
  - Locking phpunit/php-code-coverage (4.0.8)
  - Locking phpunit/php-file-iterator (1.4.5)
  - Locking phpunit/php-text-template (1.2.1)
  - Locking phpunit/php-timer (1.0.9)
  - Locking phpunit/php-token-stream (2.0.2)
  - Locking phpunit/phpunit (5.7.27)
  - Locking phpunit/phpunit-mock-objects (3.4.4)
  - Locking psr/container (1.0.0)
  - Locking psr/log (1.1.3)
  - Locking sebastian/code-unit-reverse-lookup (1.0.1)
  - Locking sebastian/comparator (1.2.4)
  - Locking sebastian/diff (1.4.3)
  - Locking sebastian/environment (2.0.0)
  - Locking sebastian/exporter (2.0.0)
  - Locking sebastian/global-state (1.1.1)
  - Locking sebastian/object-enumerator (2.0.1)
  - Locking sebastian/recursion-context (2.0.0)
  - Locking sebastian/resource-operations (1.0.0)
  - Locking sebastian/version (2.0.1)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.1.8)
  - Locking symfony/dependency-injection (v5.1.8)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.1.8)
  - Locking symfony/polyfill-ctype (v1.20.0)
  - Locking symfony/polyfill-php80 (v1.20.0)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking symfony/yaml (v4.4.16)
  - Locking technote/gutenberg-package-versions (v0.2.89)
  - Locking technote/gutenberg-packages (v1.0.3)
  - Locking webmozart/assert (1.9.1)
  - Locking wp-coding-standards/wpcs (2.3.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 46 installs, 0 updates, 0 removals
    0 [>---------------------------]    0 [>---------------------------]  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.0): Extracting archive
  - Installing sebastian/recursion-context (2.0.0): Extracting archive
  - Installing sebastian/exporter (2.0.0): Extracting archive
  - Installing sebastian/diff (1.4.3): Extracting archive
  - Installing sebastian/comparator (1.2.4): Extracting archive
  - Installing phake/phake (v2.3.2): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.0): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.20.0): Extracting archive
  - Installing webmozart/assert (1.9.1): Extracting archive
  - Installing phpdocumentor/reflection-common (2.2.0): Extracting archive
  - Installing phpdocumentor/type-resolver (1.4.0): Extracting archive
  - Installing phpdocumentor/reflection-docblock (5.2.2): Extracting archive
  - Installing symfony/filesystem (v5.1.8): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.20.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.1.8): Extracting archive
  - Installing symfony/config (v5.1.8): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.5): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing phpunit/php-token-stream (2.0.2): Extracting archive
  - Installing symfony/yaml (v4.4.16): Extracting archive
  - Installing sebastian/version (2.0.1): Extracting archive
  - Installing sebastian/resource-operations (1.0.0): Extracting archive
  - Installing sebastian/object-enumerator (2.0.1): Extracting archive
  - Installing sebastian/global-state (1.1.1): Extracting archive
  - Installing sebastian/environment (2.0.0): Extracting archive
  - Installing phpunit/php-text-template (1.2.1): Extracting archive
  - Installing doctrine/instantiator (1.4.0): Extracting archive
  - Installing phpunit/phpunit-mock-objects (3.4.4): Extracting archive
  - Installing phpunit/php-timer (1.0.9): Extracting archive
  - Installing phpunit/php-file-iterator (1.4.5): Extracting archive
  - Installing sebastian/code-unit-reverse-lookup (1.0.1): Extracting archive
  - Installing phpunit/php-code-coverage (4.0.8): Extracting archive
  - Installing phpspec/prophecy (v1.10.3): Extracting archive
  - Installing myclabs/deep-copy (1.10.2): Extracting archive
  - Installing phpunit/phpunit (5.7.27): Extracting archive
  - Installing technote/gutenberg-package-versions (v0.2.89): Extracting archive
  - Installing technote/gutenberg-packages (v1.0.3): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  0/34 [>---------------------------]   0%
 10/34 [========>-------------------]  29%
 20/34 [================>-----------]  58%
 30/34 [========================>---]  88%
 33/34 [===========================>]  97%
 34/34 [============================] 100%11 package suggestions were added by new dependencies, use `composer suggest` to see details.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
15 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for technote/gutenberg-packages
./composer.json has been updated
Running composer update technote/gutenberg-packages
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
15 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)